### PR TITLE
Add parsed EBML elements to Track objects

### DIFF
--- a/enzyme/mkv.py
+++ b/enzyme/mkv.py
@@ -134,7 +134,7 @@ class Info(object):
 class Track(object):
     """Base object for the Tracks EBML element"""
     def __init__(self, type=None, number=None, name=None, language=None, enabled=None, default=None, forced=None, lacing=None,
-                 codec_id=None, codec_name=None):
+                 codec_id=None, codec_name=None, ebml=None):
         self.type = type
         self.number = number
         self.name = name
@@ -145,6 +145,7 @@ class Track(object):
         self.lacing = lacing
         self.codec_id = codec_id
         self.codec_name = codec_name
+        self.ebml = ebml
 
     @classmethod
     def fromelement(cls, element):
@@ -165,7 +166,7 @@ class Track(object):
         codec_id = element.get('CodecID')
         codec_name = element.get('CodecName')
         return cls(type=type, number=number, name=name, language=language, enabled=enabled, default=default,
-                   forced=forced, lacing=lacing, codec_id=codec_id, codec_name=codec_name)
+                   forced=forced, lacing=lacing, codec_id=codec_id, codec_name=codec_name, ebml=element)
 
     def __repr__(self):
         return '<%s [%d, name=%r, language=%s]>' % (self.__class__.__name__, self.number, self.name, self.language)


### PR DESCRIPTION
Add parsed EBML elements to Track objects for anyone who wants/needs access to low-level information about the media container.
